### PR TITLE
Debug: Add logs to functional tests

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -26,6 +26,12 @@ jobs:
           sudo sysctl -w fs.inotify.max_user_instances=512
           docker compose up -d
 
+      - name: Display Immich logs
+        if: always()
+        run: |
+          cd ./immich-app
+          docker compose logs
+
       - name: Wait for Immich to be healthy
         run: |
           echo "Waiting for Immich to start..."

--- a/tests/functional_tests.py
+++ b/tests/functional_tests.py
@@ -5,6 +5,7 @@ import subprocess
 import time
 import uuid
 from pathlib import Path
+from datetime import datetime
 
 IMMICH_URL = os.environ.get("IMMICH_URL", "http://localhost:2283")
 API_KEY = os.environ["IMMICH_API_KEY"]
@@ -131,6 +132,5 @@ async def main():
 
 
 if __name__ == "__main__":
-    from datetime import datetime
     import asyncio
     asyncio.run(main())


### PR DESCRIPTION
This commit adds a step to the functional test workflow to print the logs from the Immich Docker containers. This is intended to help debug why the Immich server is not starting correctly.